### PR TITLE
Decouple JP/CJ from Ring

### DIFF
--- a/app/jury-president.js
+++ b/app/jury-president.js
@@ -289,20 +289,6 @@ JuryPresident.prototype.matchRoundChanged = function (toRound) {
 };
 
 /**
- * An injury has started or ended.
- * @param {Object} config
- * @param {Boolean} started
- */
-/*JuryPresident.prototype.injuryStateChanged = function (config, started) {
-	assert.object(config, 'config')
-	assert.boolean(started, 'started');
-	
-	if (started) {
-	} else {
-	}
-};*/
-
-/**
  * The match's scores have been updated.
  * @param {Object} scoreSlots
  */

--- a/app/user.js
+++ b/app/user.js
@@ -20,12 +20,11 @@ function User(id, spark, connected) {
 	assert.boolean(connected, 'connected');
 	
 	this.id = id;
+	this.connected = connected;
+	
 	if (spark) {
 		this.initSpark(spark);
 	}
-	
-	this.connected = connected;
-	this.ring = null;
 }
 
 // Inherit EventEmitter
@@ -96,11 +95,7 @@ User.prototype.idSuccess = function (ringStates) {
  */
 User.prototype.ringStateChanged = function (ringStates) {
 	assert.array(ringStates, 'ringStates');
-	
-	// Only send the updated ring states if the Jury President hasn't opened a ring yet
-	if (!this.ring) {
-		this._send('ringListView.updateList', { rings: ringStates });
-	}
+	this._send('ringListView.updateList', { rings: ringStates });
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "node" : "0.12.x" 
   },
   "scripts": {
-    "test": "mocha tests --require tests/helpers/common.js & pause",
+    "test": "mocha tests",
     "reset": "del data\\*.db",
     "restart": "node app",
     "prerestart": "npm run reset"


### PR DESCRIPTION
Do not store a reference to a ring when a JP opens it, or a CJ joins it. Instead, pass the reference only when needed and let JP/CJ decide which information to pull from it. This leads to more decoupled and testable, as well as less error-prone code.

The downside is that the new lack of reference makes it more complex for the tournament to find a ring based on a user. It now has to loop through each ring to find the one that the user opened/joined.