### PR TITLE
Vibrate when backdrop visibility changes

### DIFF
--- a/clients/corner-judge/round-view.js
+++ b/clients/corner-judge/round-view.js
@@ -63,7 +63,7 @@ RoundView.prototype.showFdb = function (data) {
 
 	// Vibrate
 	if (window.navigator.vibrate) {
-		window.navigator.vibrate(100);
+		window.navigator.vibrate(50);
 	}
 
 	// Translate the element

--- a/clients/shared/backdrop.js
+++ b/clients/shared/backdrop.js
@@ -4,15 +4,29 @@ function Backdrop() {
 	this.root = document.getElementById('backdrop');
 	this.text = this.root.querySelector('.bdp-text');
 	this.subtext = this.root.querySelector('.bdp-subtext');
+	this.isVisible = false;
 }
 
 Backdrop.prototype.update = function (text, subtext, visible) {
 	this.text.textContent = text;
 	this.subtext.textContent = subtext;
+
+	// Vibrate
+	if (window.navigator.vibrate && visible !== this.isVisible) {
+		window.navigator.vibrate(300);
+	}
+
+	this.isVisible = visible;
 	this.root.classList.toggle('hidden', !visible);
 };
 
 Backdrop.prototype.hide = function () {
+	// Vibrate
+	if (window.navigator.vibrate && this.isVisible) {
+		window.navigator.vibrate(300);
+	}
+
+	this.isVisible = false;
 	this.root.classList.add('hidden');
 };
 

--- a/clients/shared/backdrop.js
+++ b/clients/shared/backdrop.js
@@ -4,26 +4,27 @@ function Backdrop() {
 	this.root = document.getElementById('backdrop');
 	this.text = this.root.querySelector('.bdp-text');
 	this.subtext = this.root.querySelector('.bdp-subtext');
+
 	this.isVisible = false;
 }
 
 Backdrop.prototype.update = function (text, subtext, visible) {
+	// Vibrate when visiblity changes
+	if (window.navigator.vibrate && visible !== this.isVisible) {
+		window.navigator.vibrate(200);
+	}
+
 	this.text.textContent = text;
 	this.subtext.textContent = subtext;
-
-	// Vibrate
-	if (window.navigator.vibrate && visible !== this.isVisible) {
-		window.navigator.vibrate(300);
-	}
 
 	this.isVisible = visible;
 	this.root.classList.toggle('hidden', !visible);
 };
 
 Backdrop.prototype.hide = function () {
-	// Vibrate
+	// Vibrate when visiblity changes
 	if (window.navigator.vibrate && this.isVisible) {
-		window.navigator.vibrate(300);
+		window.navigator.vibrate(200);
 	}
 
 	this.isVisible = false;


### PR DESCRIPTION
Vibrate Corner Judges' devices any time the visibility of the backdrop changes. This includes:
- when they join or leave a ring
- when a round or timeout starts/ends
- when an error occurs (JP disconnected, network down, server down, etc.)
