### PR TITLE
Run gulp task to generate Primus client lib on its own

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -101,7 +101,7 @@ gulp.task('primus', function () {
  * Register one task per client.
  */
 CLIENTS.forEach(function (client) {
-	gulp.task(client + ':js', ['primus'], function () {
+	gulp.task(client + ':js', function () {
 		return browserify({
 				entries: path.join('clients', client, 'root.js'),
 				debug: true
@@ -187,5 +187,5 @@ gulp.task('default', ['build', 'scripts:lint', 'server', 'watch']);
 gulp.task('build', CLIENTS.reduce(function (arr, client) {
 	arr.push(client + ':css', client + ':js');
 	return arr;
-}, ['primus']));
+}, []));
 

--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
   },
   "scripts": {
     "build": "gulp build",
+    "prebuild": "rm -Rf \"clients/vendor\" && mkdir \"clients/vendor\" && gulp primus",
     "start": "node app",
-    "dev": "gulp",
+    "dev": "npm run prebuild && gulp",
     "reset": "gulp reset",
     "test": "mocha"
   },


### PR DESCRIPTION
... instead of as part of the `build` gulp task.